### PR TITLE
添加程序在网站子目录下的访问支持

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,13 @@
+<IfModule mod_rewrite.c>
+  Options +FollowSymlinks -MultiViews
+  RewriteEngine On
+  RewriteBase /
+
+  RewriteCond $0#%{REQUEST_URI} ([^#]*)#(.*)\1$
+  RewriteRule ^(.*)$ - [E=SUBPATH:$1,E=CWD:%2]
+  
+  RewriteCond %{DOCUMENT_ROOT}%{ENV:CWD}public/%{ENV:SUBPATH} -f
+  RewriteRule ^(.*)$ %{ENV:CWD}public/$1 [L]
+
+  RewriteRule ^(.*)$ %{ENV:CWD}public/index.php/$1 [QSA,PT,L]
+</IfModule>

--- a/app/common.php
+++ b/app/common.php
@@ -1,2 +1,36 @@
 <?php
 // 应用公共文件
+
+use think\Response;
+use think\facade\Request;
+use think\response\Redirect;
+
+/**
+ * 获取\think\response\Redirect对象实例
+ * 重写redirect方法，解决程序在子目录下的重定向地址问题
+ * @param string $url  重定向地址
+ * @param int    $code 状态码
+ * @return \think\response\Redirect
+ */
+function redirect(string $url = '', int $code = 302): Redirect
+{
+    $subUrl = '';
+    $baseUrl = Request::baseUrl(); //  获取当前请求URL的路径
+    $pathInfo = Request::pathinfo(); //  获取当前请求URL的pathinfo信息
+
+    $len = strlen($pathInfo);
+    if ($len) {
+        $subBaseUrl = substr($baseUrl, -$len);
+        if ($subBaseUrl === $pathInfo) {  //  正常情况下pathinfo信息应该在请求URL的尾部，如果不在尾部，说明用户用了不同寻常的URL重写规则，则不考虑子目录
+            $subUrl = substr($baseUrl, 0, -$len); //  移除请求URL尾部的pathinfo信息，作为子目录
+        }
+    } else {
+        $subUrl = $baseUrl; //  请求URL没有pathinfo信息，子目录为请求URL
+    }
+
+    $subUrl = rtrim($subUrl, '/');
+    $url = ltrim($url, '/');
+    $url = $subUrl . '/' . $url;
+
+    return Response::create($url, 'redirect', $code);
+}

--- a/public/static/functions.js
+++ b/public/static/functions.js
@@ -7,6 +7,7 @@
  * @link https://github.com/yuantuo666/baiduwp-php
  *
  */
+const ROOT_PATH = window.location.pathname.slice(0,-1); // 获取网站根目录
 addEventListener('DOMContentLoaded', function () {
 	window.downloadpage = new bootstrap.Modal('#downloadpage', {
 		keyboard: false,
@@ -242,6 +243,7 @@ function makeQRCode(element, text, size = 512, correctLevel = QRCode.CorrectLeve
 }
 
 async function getAPI(method) { // 获取 API 数据
+	method = ROOT_PATH + method;
 	try {
 		const response = await fetch(method, { // fetch API
 			headers: new Headers({
@@ -306,7 +308,7 @@ async function OpenRoot(surl, pwd, password = "") {
 			pwd,
 			password
 		}
-		await fetch(`/parse/list`, { // fetch API
+		await fetch(`${ROOT_PATH}/parse/list`, { // fetch API
 			credentials: 'same-origin',
 			method: 'POST',
 			body: http_build_query(data),
@@ -352,7 +354,7 @@ async function OpenDir(path) {
 			dir: path,
 			...files.dirdata
 		}
-		await fetch(`/parse/list`, { // fetch API
+		await fetch(`${ROOT_PATH}/parse/list`, { // fetch API
 			credentials: 'same-origin',
 			method: 'POST',
 			body: http_build_query(data),
@@ -460,7 +462,7 @@ async function Download(index = 0) {
 	}
 
 	try {
-		await fetch(`/parse/link`, { // fetch API
+		await fetch(`${ROOT_PATH}/parse/link`, { // fetch API
 			credentials: 'same-origin',
 			method: 'POST',
 			body: http_build_query(data),

--- a/view/admin/index.html
+++ b/view/admin/index.html
@@ -2,7 +2,7 @@
 <div class="col-md-12 col-sm-12 col-12">
     <nav>
         <ol class="breadcrumb my-4">
-            <li class="breadcrumb-item"><a href="/">baiduwp-php</a></li>
+            <li class="breadcrumb-item"><a href="./">baiduwp-php</a></li>
             <li class="breadcrumb-item"><a href="javascript:navigate('index')">后台管理</a></li>
             <li class="breadcrumb-item" id="current_path">概览</li>
         </ol>
@@ -59,7 +59,7 @@
                     }
                     const initAccountInfo = () => {
                         // 获取本地账号相关信息
-                        $.get(`/admin/account_info`, function (data, status) {
+                        $.get(`${ROOT_PATH}/admin/account_info`, function (data, status) {
                             if (data.error === 0) {
                                 $("#normal_msg").html(getAccountMsg(data.data.local_account));
                                 $("#svip_msg").html(getAccountMsg(data.data.svip_account));
@@ -129,7 +129,7 @@
                     }
 
                     const initIndexInfo = () => {
-                        fetch('/admin/info',
+                        fetch(`${ROOT_PATH}/admin/info`,
                             {
                                 headers: {
                                     'Accept': 'application/json',
@@ -206,7 +206,7 @@
                         if (result.isConfirmed) {
                             Swal.fire("正在清空，请稍等");
                             Swal.showLoading();
-                            $.post("/admin/record/clear_all", function (data, status) {
+                            $.post(`${ROOT_PATH}/admin/record/clear_all`, function (data, status) {
                                 if (status === "success") {
                                     if (data.error === 0) {
                                         Swal.fire("清空成功！", "所有解析数据已被清空。");
@@ -257,7 +257,7 @@
                 function resetAccount(id) {
                     Swal.fire("正在设置，请稍等");
                     Swal.showLoading();
-                    $.post(`/admin/account/reset/${id}`, function (data, status) {
+                    $.post(`${ROOT_PATH}/admin/account/reset/${id}`, function (data, status) {
                         if (status === "success") {
                             Swal.fire(data.msg);
                             // 对应行的数据，需要更新
@@ -555,7 +555,7 @@
         if (isNaN(newPage)) {
             newPage = 1;
         }
-        fetch(`/admin/${path}/list/${newPage}`, {
+        fetch(`${ROOT_PATH}/admin/${path}/list/${newPage}`, {
             headers: {
                 'Accept': 'application/json',
             }
@@ -586,7 +586,7 @@
         if (!isValidPath(path)) return
         Swal.fire("正在添加，请稍等");
         Swal.showLoading();
-        fetch(`/admin/${path}/add`, {
+        fetch(`${ROOT_PATH}/admin/${path}/add`, {
             method: 'POST',
             headers: {
                 'Accept': 'application/json',
@@ -612,7 +612,7 @@
         if (!isValidPath(path)) return
         Swal.fire("正在更新，请稍等");
         Swal.showLoading();
-        fetch(`/admin/${path}/update`, {
+        fetch(`${ROOT_PATH}/admin/${path}/update`, {
             method: 'POST',
             headers: {
                 'Accept': 'application/json',
@@ -649,7 +649,7 @@
             if (result.isConfirmed) {
                 Swal.fire("正在删除，请稍等");
                 Swal.showLoading();
-                fetch(`/admin/${path}/delete/${id}`, {
+                fetch(`${ROOT_PATH}/admin/${path}/delete/${id}`, {
                     method: 'POST',
                     headers: {
                         'Accept': 'application/json',

--- a/view/admin/install.html
+++ b/view/admin/install.html
@@ -3,7 +3,7 @@
 <nav>
     <ol class="breadcrumb my-4">
         <li class="breadcrumb-item"><a href="./">baiduwp-php</a></li>
-        <li class="breadcrumb-item"><a href="/install">安装程序</a></li>
+        <li class="breadcrumb-item"><a href="./install">安装程序</a></li>
     </ol>
 </nav>
 <div class="alert alert-primary" role="alert">
@@ -53,7 +53,7 @@
                     <small class="form-text">为保证安全，需要至少6位以上。</small>
                 </div>
             </div>
-            <p>其他站点设置已移动到管理员设置页面，请安装后前往 /admin 查看。</p>
+            <p>其他站点设置已移动到管理员设置页面，请安装后前往 admin 查看。</p>
             <hr />
             <h5 class="card-title">MySQL数据库设置</h5>
             <div class="form-group row">
@@ -133,7 +133,7 @@
             <script>
                 async function postAPI(method, body) { // 获取 API 数据
                     try {
-                        const response = await fetch(`/install/${method}`, { // fetch API
+                        const response = await fetch(`${ROOT_PATH}/install/${method}`, { // fetch API
                             credentials: 'same-origin', // 发送验证信息 (cookies)
                             method: 'POST',
                             headers: {
@@ -297,8 +297,8 @@
                             const data = response.data;
                             if (data.error === 0) {
                                 // 安装成功
-                                Swal.fire("安装成功", "请前往 /admin 查看站点设置。", "success").then(function(e) {
-                                    window.location.href = "/admin";
+                                Swal.fire("安装成功", `请前往 ${ROOT_PATH}/admin 查看站点设置。`, "success").then(function(e) {
+                                    window.location.href = `${ROOT_PATH}/admin`;
                                 });
                             } else {
                                 // 安装失败

--- a/view/admin/login.html
+++ b/view/admin/login.html
@@ -16,7 +16,7 @@
                 function submitForm() {
                     Swal.fire("正在登录，请稍等");
                     Swal.showLoading();
-                    fetch("/admin/login", {
+                    fetch(`${ROOT_PATH}/admin/login`, {
                         method: "POST",
                         credentials: "same-origin",
                         body: `password=${$("input[name='setting_password']").val()}`,
@@ -36,7 +36,7 @@
                     }).then(data => {
                         if (data.error === 0) {
                             Swal.fire(data.msg, data.detail, 'success');
-                            window.location.href = "/admin";
+                            window.location.href = `${ROOT_PATH}/admin`;
                         } else {
                             Swal.fire(data.msg, data.detail, 'error');
                         }

--- a/view/admin/upgrade.html
+++ b/view/admin/upgrade.html
@@ -2,8 +2,8 @@
 <!-- 升级 -->
 <nav>
     <ol class="breadcrumb my-4">
-        <li class="breadcrumb-item"><a href="./">baiduwp-php</a></li>
-        <li class="breadcrumb-item"><a href="/install/upgrade">升级程序</a></li>
+        <li class="breadcrumb-item"><a href="../">baiduwp-php</a></li>
+        <li class="breadcrumb-item"><a href="./upgrade">升级程序</a></li>
     </ol>
 </nav>
 <div class="alert alert-primary" role="alert">
@@ -64,7 +64,7 @@
         <script>
             async function postAPI(method, body) { // 获取 API 数据
                 try {
-                    const response = await fetch(`/install/${method}`, { // fetch API
+                    const response = await fetch(`${ROOT_PATH}/install/${method}`, { // fetch API
                         credentials: 'same-origin', // 发送验证信息 (cookies)
                         method: 'POST',
                         headers: {
@@ -142,8 +142,8 @@
                         const data = response.data;
                         if (data.error === 0) {
                             // 升级成功
-                            Swal.fire("升级成功", "请前往 /admin 查看站点设置。", "success").then(function (e) {
-                                window.location.href = "/admin";
+                            Swal.fire("升级成功", `请前往 ${ROOT_PATH}/admin 查看站点设置。`, "success").then(function (e) {
+                                window.location.href = `${ROOT_PATH}/admin`;
                             });
                         } else {
                             // 升级失败

--- a/view/header.html
+++ b/view/header.html
@@ -7,8 +7,8 @@
 	<meta name="author" content="Yuan_Tuo"/>
 	<meta name="version" content="<?= $program_version ?>"/>
 	<title><?= $site_name ?> - Settings</title>
-	<link rel="icon" href="favicon.ico"/>
-	<link rel="stylesheet" href="../static/index.css?v=<?= $program_version ?>"/>
+	<link rel="icon" href="<?php echo substr_count(think\facade\Request::pathinfo(), '/') == 0 ? '.' : '..'; ?>/favicon.ico"/>
+	<link rel="stylesheet" href="<?php echo substr_count(think\facade\Request::pathinfo(), '/') == 0 ? '.' : '..'; ?>/static/index.css?v=<?= $program_version ?>"/>
 	<link rel="stylesheet" href="https://cdn.staticfile.org/font-awesome/5.8.1/css/all.min.css"/>
 	<link rel="stylesheet" href="https://cdn.staticfile.org/bootstrap/5.3.0-alpha2/css/bootstrap.min.css"/>
 	<link rel="stylesheet" disabled id="Swal2-Dark"
@@ -19,9 +19,11 @@
 	<script src="https://cdn.staticfile.org/bootstrap/5.3.0-alpha2/js/bootstrap.bundle.min.js"></script>
 	<script src="https://fastly.jsdelivr.net/npm/sweetalert2@10.14.0/dist/sweetalert2.min.js"></script>
 	<script src="https://fastly.jsdelivr.net/npm/jquery-form@4.3.0/dist/jquery.form.min.js"></script>
-	<script src="../static/color.js?v=<?= $program_version ?>"></script>
+	<script src="<?php echo substr_count(think\facade\Request::pathinfo(), '/') == 0 ? '.' : '..'; ?>/static/color.js?v=<?= $program_version ?>"></script>
 	<script>
+        const ROOT_PATH = window.location.pathname.split('/').slice(0, -<?php echo substr_count(think\facade\Request::pathinfo(), '/') + 1; ?>).join('/'); // 获取根目录
         async function getAPI(method) { // 获取 API 数据
+            method = ROOT_PATH + method;
             try {
                 const response = await fetch(method, { // fetch API
                     credentials: 'same-origin' // 发送验证信息 (cookies)
@@ -45,7 +47,7 @@
             }
         }
 	</script>
-	<script src="../static/ready.js?v=<?= $program_version ?>"></script>
+	<script src="<?php echo substr_count(think\facade\Request::pathinfo(), '/') == 0 ? '.' : '..'; ?>/static/ready.js?v=<?= $program_version ?>"></script>
 </head>
 
 <body>

--- a/view/index/index.html
+++ b/view/index/index.html
@@ -45,7 +45,7 @@
                     <li class="nav-item"><a class="nav-link" href="https://github.com/yuantuo666/baiduwp-php"
                             target="_blank">Github</a></li>
                     <li class="nav-item" style="flex-grow: 1;"></li>
-                    <li class="nav-item"><a class="nav-link" href="/admin" target="_blank">管理后台</a></li>
+                    <li class="nav-item"><a class="nav-link" href="./admin" target="_blank">管理后台</a></li>
                 </ul>
             </div>
         </div>
@@ -118,7 +118,7 @@
                                     title: '未安装',
                                     text: '即将前往安装页面。'
                                 }).then(function () {
-                                    window.location.href = '/install';
+                                    window.location.href = `${ROOT_PATH}/install`;
                                 });
                             }
                             if (data.error === 1919810) {
@@ -128,7 +128,7 @@
                                     title: '安装版本和代码版本不一致',
                                     text: '需要安装更新，即将前往安装更新页面。'
                                 }).then(function () {
-                                    window.location.href = '/install/upgrade';
+                                    window.location.href = `${ROOT_PATH}/install/upgrade`;
                                 });
                             }
                             if (data.error === 0) {

--- a/view/index/message.html
+++ b/view/index/message.html
@@ -11,7 +11,7 @@
             <p class="card-text">
                 <?= $content ?>
             </p>
-            <a href="/" class="btn btn-primary">返回首页</a>
+            <a href="./" class="btn btn-primary">返回首页</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
主要改动如下：
1. view/：html标签中的绝对路径改为相对路径；根据程序页面路径判断根目录（ROOT_PATH），该变量的定义在文件中有两处，一处在header.html文件下，一处在function.js文件下；所有fetch和window.location.href的地方都添加了ROOT_PATH。
2. app/common.php：重写redirect函数，解决程序在子目录下的重定向地址问题，其它调用了redirect函数的文件不需要修改。
3. .htaccess：在程序根目录下补充一个Apache重写文件，这样支持Apache重写的虚拟主机也能做到开箱即用，不需要作额外配置（支持直接放到网站子目录）。

经测试在plesk面板下能正常工作，其它虚拟主机面板，docker，nginx环境暂未测试。